### PR TITLE
feat: New Functionalities 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A CLI tool for generating models based on a SQL Database using SQ
 license = "MIT"
 
 [dependencies]
-sqlx = { version = "0.7", features = ["postgres","runtime-tokio"] }
+sqlx = { version = "0.7", features = ["postgres", "runtime-tokio"] }
 sqlx-cli = "0.7"
 clap = "3.0"
 regex = "1.5"
@@ -14,6 +14,5 @@ chrono = "0.4"
 # regex = "1.5"
 tokio = { version = "1", features = ["full"] }
 dotenv = "0.15.0"
-testcontainers = { version ="0.15.0" }
+testcontainers = { version = "0.15.0" }
 testcontainers-modules = { version = "0.3.5", features = ["postgres"] }
-once_cell = "1.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ tokio = { version = "1", features = ["full"] }
 dotenv = "0.15.0"
 testcontainers = { version ="0.15.0" }
 testcontainers-modules = { version = "0.3.5", features = ["postgres"] }
+once_cell = "1.19.0"

--- a/src/db_queries.rs
+++ b/src/db_queries.rs
@@ -86,6 +86,7 @@ WHERE
     AND c.table_name != '_sqlx_migrations'
     AND
     ($2 IS NULL OR c.table_name = ANY($2))
+    AND c.data_type != 'USER-DEFINED'
 ORDER BY
     c.table_name,
     c.ordinal_position;

--- a/src/db_queries.rs
+++ b/src/db_queries.rs
@@ -1,6 +1,6 @@
 use sqlx::PgPool;
 
-use crate::models::TableColumn;
+use crate::models::{TableColumn, UserDefinedEnums};
 
 pub async fn get_table_columns(
     pool: &PgPool,
@@ -86,7 +86,6 @@ WHERE
     AND c.table_name != '_sqlx_migrations'
     AND
     ($2 IS NULL OR c.table_name = ANY($2))
-    AND c.data_type != 'USER-DEFINED'
 ORDER BY
     c.table_name,
     c.ordinal_position;
@@ -95,6 +94,31 @@ ORDER BY
     let rows = sqlx::query_as::<_, TableColumn>(query)
         .bind(schemas)
         .bind(table_names)
+        .fetch_all(pool)
+        .await?;
+    Ok(rows)
+}
+
+pub async fn get_user_defined_enums(
+    udt_names: &Vec<String>,
+    pool: &PgPool,
+) -> sqlx::Result<Vec<UserDefinedEnums>> {
+    let query = "
+        SELECT
+            t.typname AS enum_name,
+            e.enumlabel AS enum_value
+        FROM
+            pg_type t
+            JOIN pg_enum e ON t.oid = e.enumtypid
+        WHERE
+            t.typname = ANY($1)
+        ORDER BY
+            t.typname,
+            e.enumsortorder;
+            ";
+
+    let rows = sqlx::query_as::<_, UserDefinedEnums>(query)
+        .bind(udt_names)
         .fetch_all(pool)
         .await?;
     Ok(rows)

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -15,6 +15,7 @@ pub async fn generate(
     context: Option<&str>,
     force: bool,
     include_tables: Option<Vec<&str>>,
+    exclude_tables: Vec<String>,
     schemas: Option<Vec<&str>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Connect to the Postgres database
@@ -36,7 +37,12 @@ pub async fn generate(
     for row in &rows {
         unique.insert(row.table_name.clone());
     }
-    let tables: Vec<String> = unique.into_iter().collect::<Vec<String>>();
+    let tables: Vec<String> = unique
+        .into_iter()
+        .collect::<Vec<String>>()
+        .into_iter()
+        .filter(|e| !exclude_tables.contains(e))
+        .collect();
 
     println!("Outputting tables: {:?}", tables);
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -8,6 +8,8 @@ use crate::models::TableColumn;
 use crate::utils::{generate_enum_code, generate_struct_code, to_pascal_case, to_snake_case};
 
 use crate::query_generate::generate_query_code;
+use crate::utils::{DateTimeLib, SqlGenState};
+use crate::STATE;
 
 pub async fn generate(
     enable_serde: bool,
@@ -18,6 +20,7 @@ pub async fn generate(
     include_tables: Option<Vec<&str>>,
     exclude_tables: Vec<String>,
     schemas: Option<Vec<&str>>,
+    date_time_lib: DateTimeLib,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Connect to the Postgres database
     let pool = PgPoolOptions::new()
@@ -65,6 +68,13 @@ pub async fn generate(
         println!("Outputting user defined enums: {:?}", enums);
     }
     println!("Outputting tables: {:?}", tables);
+
+    STATE
+        .set(SqlGenState {
+            user_defined: enums.clone(),
+            date_time_lib,
+        })
+        .expect("Unable to set state");
 
     let mut rs_enums = Vec::new();
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -10,6 +10,7 @@ use crate::utils::{generate_struct_code, to_pascal_case, to_snake_case};
 use crate::query_generate::generate_query_code;
 
 pub async fn generate(
+    enable_serde: bool,
     output_folder: &str,
     database_url: &str,
     context: Option<&str>,
@@ -54,7 +55,7 @@ pub async fn generate(
             }
         }
         // Generate the struct code based on the row
-        let struct_code = generate_struct_code(&table, &rows);
+        let struct_code = generate_struct_code(&table, &rows, enable_serde);
 
         // Generate the query code based on the row
         let query_code = generate_query_code(&table, &rows);

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -3,9 +3,9 @@ use sqlx::PgPool;
 use std::fs;
 use std::path::Path;
 
-use crate::db_queries::get_table_columns;
+use crate::db_queries::{get_table_columns, get_user_defined_enums};
 use crate::models::TableColumn;
-use crate::utils::{generate_struct_code, to_pascal_case, to_snake_case};
+use crate::utils::{generate_enum_code, generate_struct_code, to_pascal_case, to_snake_case};
 
 use crate::query_generate::generate_query_code;
 
@@ -30,7 +30,23 @@ pub async fn generate(
 
     let default_schema = "public";
     let rows = get_table_columns(&pool, schemas.unwrap_or(vec![default_schema]), None).await?;
+    let user_defined = rows
+        .iter()
+        .filter_map(|e| {
+            if e.data_type.as_str() == "USER-DEFINED" && e.udt_name.as_str() != "geometry" {
+                Some(e.udt_name.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<String>>();
 
+    let enum_rows = get_user_defined_enums(&user_defined, &pool).await?;
+    let mut unique_enums = std::collections::BTreeSet::new();
+    for row in &enum_rows {
+        unique_enums.insert(row.enum_name.clone());
+    }
+    let enums = unique_enums.into_iter().collect::<Vec<String>>();
     // Create the output folder if it doesn't exist
     fs::create_dir_all(output_folder)?;
 
@@ -45,7 +61,17 @@ pub async fn generate(
         .filter(|e| !exclude_tables.contains(e))
         .collect();
 
+    if !enums.is_empty() {
+        println!("Outputting user defined enums: {:?}", enums);
+    }
     println!("Outputting tables: {:?}", tables);
+
+    let mut rs_enums = Vec::new();
+
+    for user_enum in enums {
+        let enum_code = generate_enum_code(&user_enum, &enum_rows, enable_serde);
+        rs_enums.push(enum_code);
+    }
 
     // Generate structs and queries for each table
     for table in &tables {
@@ -82,18 +108,28 @@ pub async fn generate(
         }
     }
 
-    let context_code = generate_db_context(context.unwrap_or(&database_name), &tables, &rows);
+    let context_code =
+        generate_db_context(context.unwrap_or(&database_name), &rs_enums, &tables, &rows);
     let context_file_path = format!("{}/mod.rs", output_folder);
     fs::write(context_file_path, context_code)?;
     Ok(())
 }
 
-fn generate_db_context(database_name: &str, tables: &[String], _rows: &[TableColumn]) -> String {
+fn generate_db_context(
+    database_name: &str,
+    enums: &[String],
+    tables: &[String],
+    _rows: &[TableColumn],
+) -> String {
     let mut db_context_code = String::new();
 
     db_context_code.push_str("#![allow(dead_code)]\n");
     db_context_code
         .push_str("// Generated with sql-gen\n//https://github.com/jayy-lmao/sql-gen\n\n");
+    for enum_item in enums {
+        db_context_code.push_str(enum_item);
+        db_context_code.push_str("\n\n");
+    }
     for table in tables {
         db_context_code.push_str(&format!("pub mod {};\n", to_snake_case(table)));
         db_context_code.push_str(&format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
+use std::sync::OnceLock;
+
 use clap::{App, Arg, SubCommand};
-use once_cell::sync::OnceCell;
 use utils::{DateTimeLib, SqlGenState};
 
 mod db_queries;
@@ -9,7 +10,7 @@ mod models;
 mod query_generate;
 mod utils;
 
-pub static STATE: OnceCell<SqlGenState> = OnceCell::new();
+pub(crate) static STATE: OnceLock<SqlGenState> = OnceLock::new();
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("serde")
+                .long("serde")
+                .default_value("true")
+                .value_name("SQLGEN_ENABLE_SERDE")
+                .help("Adds Serde derices to created structs")
+                .takes_value(false),
+        )
+        .arg(
             Arg::with_name("migrations")
                 .short('m')
                 .long("migrations")
@@ -219,7 +227,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Excluding tables: {:?}", exclude_tables);
         }
 
+        let enable_serde = matches.is_present("serde");
+
         generate::generate(
+            enable_serde,
             output_folder,
             database_url,
             context,

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,4 @@
-#[derive(sqlx::FromRow)]
+#[derive(sqlx::FromRow, Clone)]
 pub struct TableColumn {
     pub(crate) table_name: String,
     pub(crate) column_name: String,

--- a/src/models.rs
+++ b/src/models.rs
@@ -12,3 +12,9 @@ pub struct TableColumn {
     // #todo
     pub(crate) table_schema: String,
 }
+
+#[derive(sqlx::FromRow, Clone)]
+pub struct UserDefinedEnums {
+    pub(crate) enum_name: String,
+    pub(crate) enum_value: String,
+}

--- a/src/query_generate.rs
+++ b/src/query_generate.rs
@@ -28,14 +28,14 @@ pub fn generate_query_code(table_name: &str, rows: &[TableColumn]) -> String {
     query_code.push_str(&format!("impl {}Set {{\n", struct_name));
 
     // Generate query code for SELECT statements
-    query_code.push_str(&generate_select_query_code(table_name, schema_name, rows));
+    query_code.push_str(&generate_select_query_code(table_name, schema_name, &rows));
     query_code.push('\n');
 
     // Generate query code for SELECT BY PK statements
     query_code.push_str(&generate_select_by_pk_query_code(
         table_name,
         schema_name,
-        rows,
+        &rows,
     ));
     query_code.push('\n');
 
@@ -43,7 +43,7 @@ pub fn generate_query_code(table_name: &str, rows: &[TableColumn]) -> String {
     query_code.push_str(&generate_select_many_by_pks_query_code(
         table_name,
         schema_name,
-        rows,
+        &rows,
     ));
     query_code.push('\n');
 
@@ -51,30 +51,30 @@ pub fn generate_query_code(table_name: &str, rows: &[TableColumn]) -> String {
     query_code.push_str(&generate_select_by_pk_query_code_optional(
         table_name,
         schema_name,
-        rows,
+        &rows,
     ));
     query_code.push('\n');
 
-    query_code.push_str(&generate_unique_query_code(table_name, schema_name, rows));
-    query_code.push('\n');
+    // query_code.push_str(&generate_unique_query_code(table_name, schema_name, &rows));
+    // query_code.push('\n');
 
     query_code.push_str(&generate_select_all_fk_queries(
         table_name,
         schema_name,
-        rows,
+        &rows,
     ));
     query_code.push('\n');
 
     // Generate query code for INSERT statements
-    query_code.push_str(&generate_insert_query_code(table_name, schema_name, rows));
+    query_code.push_str(&generate_insert_query_code(table_name, schema_name, &rows));
     query_code.push('\n');
 
     // Generate query code for UPDATE statements
-    query_code.push_str(&generate_update_query_code(table_name, schema_name, rows));
+    query_code.push_str(&generate_update_query_code(table_name, schema_name, &rows));
     query_code.push('\n');
 
     // Generate query code for DELETE statements
-    query_code.push_str(&generate_delete_query_code(table_name, schema_name, rows));
+    query_code.push_str(&generate_delete_query_code(table_name, schema_name, &rows));
     query_code.push('\n');
 
     query_code.push_str("}\n");
@@ -121,9 +121,14 @@ fn generate_select_by_pk_query_code(
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
         .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
             format!(
                 "{}: {}",
-                r.column_name,
+                column_name,
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -146,7 +151,14 @@ fn generate_select_by_pk_query_code(
     let bind = rows
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
-        .map(|r| format!("            .bind({})\n", r.column_name))
+        .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
+            format!("            .bind({})\n", column_name)
+        })
         .collect::<Vec<String>>()
         .join("");
 
@@ -185,9 +197,14 @@ fn generate_select_many_by_pks_query_code(
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
         .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
             format!(
                 "{}_list: Vec<{}>",
-                r.column_name,
+                column_name,
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -210,7 +227,14 @@ fn generate_select_many_by_pks_query_code(
     let bind = rows
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
-        .map(|r| format!("            .bind({}_list)\n", r.column_name))
+        .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
+            format!("            .bind({}_list)\n", column_name)
+        })
         .collect::<Vec<String>>()
         .join("");
 
@@ -244,9 +268,14 @@ fn generate_select_by_pk_query_code_optional(
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
         .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
             format!(
                 "{}: {}",
-                r.column_name,
+                column_name,
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -271,7 +300,14 @@ fn generate_select_by_pk_query_code_optional(
     let bind = rows
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
-        .map(|r| format!("            .bind({})\n", r.column_name))
+        .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
+            format!("            .bind({})\n", column_name)
+        })
         .collect::<Vec<String>>()
         .join("");
 
@@ -337,9 +373,14 @@ fn generate_select_by_unique_query_code(
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
         .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
             format!(
                 "{}: {}",
-                r.column_name,
+                column_name,
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -347,7 +388,7 @@ fn generate_select_by_unique_query_code(
         .join(", ");
 
     select_code.push_str(&format!(
-        "    pub async fn by_{}<'e, E: PgExecutor<'e>>(&self, executor: E, {}) -> Result<{}> {{\n",
+        "    pub async fn unique_by_{}<'e, E: PgExecutor<'e>>(&self, executor: E, {}) -> Result<{}> {{\n",
         unique_name, fn_args, struct_name
     ));
 
@@ -362,7 +403,14 @@ fn generate_select_by_unique_query_code(
     let bind = rows
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
-        .map(|r| format!("            .bind({})\n", r.column_name))
+        .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
+            format!("            .bind({})\n", column_name)
+        })
         .collect::<Vec<String>>()
         .join("");
 
@@ -396,9 +444,14 @@ fn generate_select_many_by_uniques_query_code(
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
         .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
             format!(
                 "{}_list: Vec<{}>",
-                r.column_name,
+                column_name,
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -406,7 +459,7 @@ fn generate_select_many_by_uniques_query_code(
         .join(", ");
 
     select_code.push_str(&format!(
-        "    pub async fn many_by_{}_list<'e, E: PgExecutor<'e>>(&self, executor: E, {}) -> Result<Vec<{}>> {{\n",
+        "    pub async fn unique_many_by_{}_list<'e, E: PgExecutor<'e>>(&self, executor: E, {}) -> Result<Vec<{}>> {{\n",
         unique_name, fn_args, struct_name
     ));
 
@@ -421,7 +474,14 @@ fn generate_select_many_by_uniques_query_code(
     let bind = rows
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
-        .map(|r| format!("            .bind({}_list)\n", r.column_name))
+        .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
+            format!("            .bind({}_list)\n", column_name)
+        })
         .collect::<Vec<String>>()
         .join("");
 
@@ -450,9 +510,14 @@ fn generate_select_by_unique_query_code_optional(
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
         .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
             format!(
                 "{}: {}",
-                r.column_name,
+                column_name,
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -460,7 +525,7 @@ fn generate_select_by_unique_query_code_optional(
         .join(", ");
 
     select_code.push_str(&format!(
-        "    pub async fn by_{}_optional<'e, E: PgExecutor<'e>>(&self, executor: E, {}) -> Result<Option<{}>> {{\n",
+        "    pub async fn unique_by_{}_optional<'e, E: PgExecutor<'e>>(&self, executor: E, {}) -> Result<Option<{}>> {{\n",
         unique_name,
         fn_args,
         struct_name
@@ -477,7 +542,14 @@ fn generate_select_by_unique_query_code_optional(
     let bind = rows
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
-        .map(|r| format!("            .bind({})\n", r.column_name))
+        .map(|r| {
+            let column_name = if r.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &r.column_name
+            };
+            format!("            .bind({})\n", column_name)
+        })
         .collect::<Vec<String>>()
         .join("");
 
@@ -543,7 +615,7 @@ fn generate_select_by_fk_query_code(
     select_code.push_str(&format!(
         "    pub async fn all_by_{}_{}<'e, E: PgExecutor<'e>>(executor: E, {}_{}: {}) -> Result<Vec<{}>> {{\n",
         to_snake_case(foreign_row_table_name),
-        foreign_row_column_name,
+        to_snake_case(column_name),
         to_snake_case(foreign_row_table_name),
         foreign_row_column_name,
         data_type,
@@ -569,6 +641,7 @@ fn generate_select_by_fk_query_code(
 fn generate_insert_query_code(table_name: &str, schema_name: &str, rows: &[TableColumn]) -> String {
     let struct_name = to_pascal_case(table_name);
     let mut insert_code = String::new();
+
     insert_code.push_str(&format!(
         "    pub async fn insert<'e, E: PgExecutor<'e>>(&self, executor: E, {}: {}) -> Result<{}> {{\n",
         to_snake_case(table_name),
@@ -659,10 +732,15 @@ fn generate_value_list(table_name: &str, rows: &[TableColumn]) -> String {
     rows.iter()
         .filter(|row| row.table_name == table_name)
         .map(|row| {
+            let column_name = if row.column_name.as_str() == "type" {
+                "r#type"
+            } else {
+                &row.column_name
+            };
             format!(
                 ".bind({}.{})",
                 to_snake_case(&row.table_name),
-                to_snake_case(&row.column_name)
+                to_snake_case(column_name)
             )
         })
         .collect::<Vec<_>>()

--- a/src/query_generate.rs
+++ b/src/query_generate.rs
@@ -1,6 +1,6 @@
 use crate::{
     models::TableColumn,
-    utils::{convert_data_type, to_pascal_case, to_snake_case},
+    utils::{convert_data_type, rust_type_fix, to_pascal_case, to_snake_case},
 };
 
 pub fn generate_query_code(table_name: &str, rows: &[TableColumn]) -> String {
@@ -121,14 +121,9 @@ fn generate_select_by_pk_query_code(
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
             format!(
                 "{}: {}",
-                column_name,
+                rust_type_fix(r.column_name.as_str()),
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -152,12 +147,10 @@ fn generate_select_by_pk_query_code(
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
-            format!("            .bind({})\n", column_name)
+            format!(
+                "            .bind({})\n",
+                rust_type_fix(r.column_name.as_str())
+            )
         })
         .collect::<Vec<String>>()
         .join("");
@@ -197,14 +190,9 @@ fn generate_select_many_by_pks_query_code(
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
             format!(
                 "{}_list: Vec<{}>",
-                column_name,
+                rust_type_fix(r.column_name.as_str()),
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -228,12 +216,10 @@ fn generate_select_many_by_pks_query_code(
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
-            format!("            .bind({}_list)\n", column_name)
+            format!(
+                "            .bind({}_list)\n",
+                rust_type_fix(r.column_name.as_str())
+            )
         })
         .collect::<Vec<String>>()
         .join("");
@@ -268,14 +254,9 @@ fn generate_select_by_pk_query_code_optional(
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
             format!(
                 "{}: {}",
-                column_name,
+                rust_type_fix(r.column_name.as_str()),
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -301,12 +282,10 @@ fn generate_select_by_pk_query_code_optional(
         .iter()
         .filter(|r| r.is_primary_key && r.table_name == table_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
-            format!("            .bind({})\n", column_name)
+            format!(
+                "            .bind({})\n",
+                rust_type_fix(r.column_name.as_str())
+            )
         })
         .collect::<Vec<String>>()
         .join("");
@@ -373,14 +352,9 @@ fn generate_select_by_unique_query_code(
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
             format!(
                 "{}: {}",
-                column_name,
+                rust_type_fix(r.column_name.as_str()),
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -404,12 +378,10 @@ fn generate_select_by_unique_query_code(
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
-            format!("            .bind({})\n", column_name)
+            format!(
+                "            .bind({})\n",
+                rust_type_fix(r.column_name.as_str())
+            )
         })
         .collect::<Vec<String>>()
         .join("");
@@ -444,14 +416,9 @@ fn generate_select_many_by_uniques_query_code(
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
             format!(
                 "{}_list: Vec<{}>",
-                column_name,
+                rust_type_fix(r.column_name.as_str()),
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -475,12 +442,10 @@ fn generate_select_many_by_uniques_query_code(
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
-            format!("            .bind({}_list)\n", column_name)
+            format!(
+                "            .bind({}_list)\n",
+                rust_type_fix(r.column_name.as_str())
+            )
         })
         .collect::<Vec<String>>()
         .join("");
@@ -510,14 +475,9 @@ fn generate_select_by_unique_query_code_optional(
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
             format!(
                 "{}: {}",
-                column_name,
+                rust_type_fix(r.column_name.as_str()),
                 convert_data_type(r.udt_name.as_str())
             )
         })
@@ -543,12 +503,10 @@ fn generate_select_by_unique_query_code_optional(
         .iter()
         .filter(|r| r.is_unique && r.table_name == table_name && r.column_name == unique_name)
         .map(|r| {
-            let column_name = if r.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &r.column_name
-            };
-            format!("            .bind({})\n", column_name)
+            format!(
+                "            .bind({})\n",
+                rust_type_fix(r.column_name.as_str())
+            )
         })
         .collect::<Vec<String>>()
         .join("");
@@ -732,15 +690,11 @@ fn generate_value_list(table_name: &str, rows: &[TableColumn]) -> String {
     rows.iter()
         .filter(|row| row.table_name == table_name)
         .map(|row| {
-            let column_name = if row.column_name.as_str() == "type" {
-                "r#type"
-            } else {
-                &row.column_name
-            };
+            let column_name = rust_type_fix(row.column_name.as_str());
             format!(
                 ".bind({}.{})",
                 to_snake_case(&row.table_name),
-                to_snake_case(column_name)
+                to_snake_case(&column_name)
             )
         })
         .collect::<Vec<_>>()

--- a/src/query_generate.rs
+++ b/src/query_generate.rs
@@ -598,7 +598,7 @@ fn generate_select_by_fk_query_code(
     select_code.push_str(&format!(
         "    pub async fn all_by_{}_{}<'e, E: PgExecutor<'e>>(executor: E, {}_{}: {}) -> Result<Vec<{}>> {{\n",
         to_snake_case(foreign_row_table_name),
-        to_snake_case(column_name),
+        foreign_row_column_name,
         to_snake_case(foreign_row_table_name),
         foreign_row_column_name,
         data_type,

--- a/src/query_generate.rs
+++ b/src/query_generate.rs
@@ -598,7 +598,7 @@ fn generate_select_by_fk_query_code(
     select_code.push_str(&format!(
         "    pub async fn all_by_{}_{}<'e, E: PgExecutor<'e>>(executor: E, {}_{}: {}) -> Result<Vec<{}>> {{\n",
         to_snake_case(foreign_row_table_name),
-        foreign_row_column_name,
+        to_snake_case(column_name),
         to_snake_case(foreign_row_table_name),
         foreign_row_column_name,
         data_type,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -168,7 +168,7 @@ pub fn convert_data_type(data_type: &str) -> String {
         "int8" | "bigint" | "bigserial" => "i64",
         "void" => "()",
         "jsonb" | "json" => "serde_json::Value",
-        "text" | "_text" | "varchar" | "name" | "citext" => "String",
+        "text" | "varchar" | "name" | "citext" => "String",
         "geometry" => "String", // when sqlx supports geo types we could change this
         "time" => state.date_time_lib.time_type(),
         "timestamp" => state.date_time_lib.timestamp_type(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,13 +20,26 @@ pub(crate) fn to_snake_case(input: &str) -> String {
     output
 }
 
-pub fn generate_struct_code(table_name: &str, rows: &Vec<TableColumn>) -> String {
+pub fn generate_struct_code(
+    table_name: &str,
+    rows: &Vec<TableColumn>,
+    enable_serde: bool,
+) -> String {
     let struct_name = to_pascal_case(table_name);
     let mut struct_code = String::new();
 
+    let serde_derives = if enable_serde {
+        ", serde::Serialize, serde::Deserialize"
+    } else {
+        ""
+    };
+
     struct_code.push_str("#![allow(dead_code)]\n");
     struct_code.push_str("// Generated with sql-gen\n// https://github.com/jayy-lmao/sql-gen\n\n");
-    struct_code.push_str("#[derive(sqlx::FromRow, Debug)]\n");
+    struct_code.push_str(&format!(
+        "#[derive(sqlx::FromRow, Debug, Clone{})]\n",
+        serde_derives
+    ));
     struct_code.push_str(&format!("pub struct {} {{\n", struct_name));
 
     for row in rows {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,12 @@ pub(crate) enum DateTimeLib {
     Chrono,
 }
 
+impl Default for DateTimeLib {
+    fn default() -> Self {
+        DateTimeLib::Chrono
+    }
+}
+
 impl DateTimeLib {
     pub(crate) fn date_type(&self) -> &str {
         match self {
@@ -46,7 +52,7 @@ impl From<String> for DateTimeLib {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct SqlGenState {
     pub user_defined: Vec<String>,
     pub date_time_lib: DateTimeLib,


### PR DESCRIPTION
closes #12 

I wanted to bypass geo types by making it String on the rust side to store the geom from SQL as a string. I've also added new features to integrate my project more.  

Added:
- Rust Enum creation based on SQL Enum types
- Optional `--serde` flag if you wanna derive structs/enums with serde
- Optional `--datetime-lib` to select `time` or `chrono` crate to use. defaults to `chrono`

Fixed:
- If the column name is `type`, it's a reserved keyword in Rust. So, I created a helper function `rust_type_fix`. (naming could be better)

Notes:
- I haven't try the migrate command yet, I only needed generate command