### PR TITLE
fix: postgres array_depth i16 to i32.

### DIFF
--- a/src/core/models/db.rs
+++ b/src/core/models/db.rs
@@ -8,7 +8,7 @@ pub struct TableColumn {
     pub data_type: String,
     pub recommended_rust_type: Option<String>,
     pub is_nullable: bool,
-    pub array_depth: i16,
+    pub array_depth: i32,
     pub is_unique: bool,
     pub is_primary_key: bool,
     pub foreign_key_table: Option<String>,
@@ -47,7 +47,7 @@ pub struct TableColumnBuilder {
     udt_name: String,
     data_type: String,
     is_nullable: bool,
-    array_depth: i16,
+    array_depth: i32,
     is_unique: bool,
     is_primary_key: bool,
     foreign_key_table: Option<String>,
@@ -83,7 +83,7 @@ impl TableColumnBuilder {
         self
     }
 
-    pub fn array_depth(mut self, depth: i16) -> Self {
+    pub fn array_depth(mut self, depth: i32) -> Self {
         self.array_depth = depth;
         self
     }

--- a/src/core/models/rust.rs
+++ b/src/core/models/rust.rs
@@ -27,7 +27,7 @@ pub struct RustDbSetField {
     pub field_name: String,
     pub field_type: String,
     pub is_optional: bool,
-    pub array_depth: i16,
+    pub array_depth: i32,
     pub attributes: Vec<RustDbSetAttribute>,
     pub comment: Option<String>,
 }

--- a/src/mysql/models/mysql_table_column.rs
+++ b/src/mysql/models/mysql_table_column.rs
@@ -11,7 +11,7 @@ pub struct MySqlTableColumn {
     pub udt_name: String,
     pub data_type: String,
     pub is_nullable: bool,
-    pub array_depth: i16,
+    pub array_depth: i32,
     pub is_unique: bool,
     pub is_primary_key: bool,
     pub foreign_key_table: Option<String>,

--- a/src/postgres/models/postgres_table_column.rs
+++ b/src/postgres/models/postgres_table_column.rs
@@ -11,7 +11,7 @@ pub struct PostgresTableColumn {
     pub udt_name: String,
     pub data_type: String,
     pub is_nullable: bool,
-    pub array_depth: i16,
+    pub array_depth: i32,
     pub is_unique: bool,
     pub is_primary_key: bool,
     pub foreign_key_table: Option<String>,


### PR DESCRIPTION
fixes https://github.com/jayy-lmao/sql-gen/issues/20

Needs review, this is also more of a demonstration than a PR to confirm my assumptions related to the issue.
I haven't tested on INT2. But for INT4 it works...

I also don't know the impact of this PR on mysql yet, it does change some files related to mysql. But have tested on postgres on my setup (in that issue's repro) and it works (it generated files under src/models):
<img width="1195" height="660" alt="image" src="https://github.com/user-attachments/assets/c7fb0181-7f27-4c7f-81b2-47765d374a6e" />


