### PR TITLE
Implements public-fields flag

### DIFF
--- a/src/core/models/rust.rs
+++ b/src/core/models/rust.rs
@@ -8,6 +8,13 @@ pub struct RustDbSetStruct {
 }
 
 #[derive(Debug, PartialEq, Default, Clone)]
+pub enum Visibility {
+    #[default]
+    Private,
+    Public,
+}
+
+#[derive(Debug, PartialEq, Default, Clone)]
 pub struct RustDbSetEnumVariant {
     pub name: String,
     pub attributes: Vec<RustDbSetAttribute>,
@@ -24,6 +31,7 @@ pub struct RustDbSetEnum {
 
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct RustDbSetField {
+    pub field_visibility: Visibility,
     pub field_name: String,
     pub field_type: String,
     pub is_optional: bool,

--- a/src/core/translators/convert_column_to_field.rs
+++ b/src/core/translators/convert_column_to_field.rs
@@ -1,7 +1,7 @@
 use crate::{
     core::models::{
         db::TableColumn,
-        rust::{auto_attribute, key_attribute, unique_attribute, RustDbSetField},
+        rust::{auto_attribute, key_attribute, unique_attribute, RustDbSetField, Visibility},
     },
     Mode,
 };
@@ -13,6 +13,10 @@ pub fn convert_column_to_field(
     column: &TableColumn,
     options: ColumnToFieldOptions,
 ) -> Option<RustDbSetField> {
+    let field_visibility = match options.public_fields {
+        true => Visibility::Public,
+        false => Visibility::Private,
+    };
     let field_name = options
         .override_name
         .unwrap_or(column.column_name.to_case(Case::Snake));
@@ -36,6 +40,7 @@ pub fn convert_column_to_field(
 
     if let Some(field_type) = maybe_field_type {
         return Some(RustDbSetField {
+            field_visibility,
             field_name,
             field_type,
             is_optional: column.is_nullable,

--- a/src/core/translators/convert_table_to_struct.rs
+++ b/src/core/translators/convert_table_to_struct.rs
@@ -42,6 +42,7 @@ pub fn convert_table_to_struct(table: Table, options: &CodegenOptions) -> RustDb
 
             let mut column_to_field_options = column_override.or(type_override).unwrap_or_default();
             column_to_field_options.mode = options.mode;
+            column_to_field_options.public_fields = options.public_fields;
             let field = convert_column_to_field(c, column_to_field_options);
             if field.is_none() {
                 println!("WARNING: field {} in table {} has no user-defined type or recommended type for {}", c.column_name,&table.table_name,c.udt_name)

--- a/src/core/translators/convert_table_to_struct_test.rs
+++ b/src/core/translators/convert_table_to_struct_test.rs
@@ -324,6 +324,7 @@ fn should_convert_table_with_column_type_override() {
         override_name: None,
         override_type: Some("String".to_string()),
         mode: Mode::Dbset,
+        public_fields: false,
     };
     let mut table_to_struct_options = CodegenOptions::default();
     table_to_struct_options.set_mode(Mode::Dbset);
@@ -361,6 +362,7 @@ fn should_convert_table_with_global_type_override() {
         override_name: None,
         override_type: Some("String".to_string()),
         mode: Mode::Dbset,
+        public_fields: false,
     };
     let mut table_to_struct_options = CodegenOptions::default();
     table_to_struct_options.set_mode(Mode::Dbset);
@@ -398,11 +400,13 @@ fn column_override_takes_preference_over_global_type_override() {
         override_name: None,
         override_type: Some("String".to_string()),
         mode: Mode::Dbset,
+        public_fields: false,
     };
     let column_override = ColumnToFieldOptions {
         override_name: None,
         override_type: Some("rust_decimal::Decimal".to_string()),
         mode: Mode::Dbset,
+        public_fields: false,
     };
 
     let mut table_to_struct_options = CodegenOptions::default();

--- a/src/core/translators/models.rs
+++ b/src/core/translators/models.rs
@@ -15,6 +15,7 @@ pub struct CodegenOptions {
     pub table_column_overrides: HashMap<(TableName, ColumnName), ColumnToFieldOptions>,
     pub column_overrides: HashMap<ColumnName, ColumnToFieldOptions>,
     pub type_overrides: HashMap<TypeName, ColumnToFieldOptions>,
+    pub public_fields: bool,
 }
 
 impl CodegenOptions {
@@ -45,6 +46,7 @@ impl CodegenOptions {
                     self.add_type_override(
                         qualifier,
                         ColumnToFieldOptions {
+                            public_fields: self.public_fields,
                             override_name: None,
                             override_type: Some(override_type.to_string()),
                             mode: self.mode,
@@ -66,6 +68,7 @@ impl CodegenOptions {
                             table_name,
                             column_name,
                             ColumnToFieldOptions {
+                                public_fields: self.public_fields,
                                 override_name: None,
                                 mode: self.mode,
                                 override_type: Some(override_type.to_string()),
@@ -76,6 +79,7 @@ impl CodegenOptions {
                     self.add_column_override(
                         qualifier,
                         ColumnToFieldOptions {
+                            public_fields: self.public_fields,
                             override_name: None,
                             mode: self.mode,
                             override_type: Some(override_type.to_string()),
@@ -128,6 +132,7 @@ impl CodegenOptions {
                     override_name: None,
                     override_type: Some(rust_enum.name),
                     mode: self.mode,
+                    public_fields: self.public_fields,
                 },
             );
         }
@@ -139,4 +144,5 @@ pub struct ColumnToFieldOptions {
     pub override_name: Option<String>,
     pub override_type: Option<String>,
     pub mode: Mode,
+    pub public_fields: bool,
 }

--- a/src/core/writers/struct_writer.rs
+++ b/src/core/writers/struct_writer.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use super::helpers::{get_attributes, get_derives, pretty_print_tokenstream, sanitize_field_name};
-use crate::core::models::rust::{RustDbSetField, RustDbSetStruct};
+use crate::core::models::rust::{RustDbSetField, RustDbSetStruct, Visibility};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
@@ -21,6 +21,10 @@ fn get_struct_fields_tokens(rust_struct: &RustDbSetStruct) -> Vec<TokenStream> {
     let mut struct_fields_tokens = vec![];
 
     for field in rust_struct.fields.iter() {
+        let field_visibility = match field.field_visibility {
+            Visibility::Public => quote! { pub },
+            Visibility::Private => quote! {},
+        };
         let field_name = sanitize_field_name(&field.field_name);
         //let field_type = format_ident!("{}", field.field_type);
         let field_type: syn::Path =
@@ -39,7 +43,7 @@ fn get_struct_fields_tokens(rust_struct: &RustDbSetStruct) -> Vec<TokenStream> {
 
         let field = quote! {
             #attributes
-            #field_name: #base_type
+            #field_visibility #field_name: #base_type
         };
 
         struct_fields_tokens.push(field);

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,10 @@ struct Cli {
     )]
     table_overrides: Vec<String>,
 
+    /// Public-fields flag (if set, struct fields will be public).
+    #[arg(long = "public-fields")]
+    public_fields: bool,
+
     /// Output .
     #[arg(long, default_value = "src/models/")]
     output: String,
@@ -144,6 +148,7 @@ async fn generate_rust_from_database(args: &Cli) -> DbSetsFsWriter {
     options.add_enums(&enums);
     options.set_model_derives(&args.model_derives);
     options.set_enum_derives(&args.enum_derives);
+    options.public_fields = args.public_fields;
 
     let structs_mapped =
         translators::convert_table_to_struct::convert_tables_to_struct(tables, &options);


### PR DESCRIPTION
I like my pure data structs to have public fields.
AFAIK, your crate make them by default private and there is no way to change that.
So, i have implemented a `-- public-fields` flag that makes all structs fields prefixed with `pub`.
I have tried to respect your project structure, which is very clean, btw. 
I hope you will like it.