### PR TITLE
Fix : dependencies not detected when field type is Option<T>

### DIFF
--- a/src/core/writers/fs_writer.rs
+++ b/src/core/writers/fs_writer.rs
@@ -84,7 +84,10 @@ impl DbSetsFsWriter {
     ) -> Vec<String> {
         known_types
             .iter()
-            .filter(|&t| content.contains(&format!(": {t}")) && t != struct_or_enum_name) // Check if struct/enum name appears in the content
+            .filter(|&t| {
+                (content.contains(&format!(": {t}")) || content.contains(&format!(": Option<{t}>")))
+                    && t != struct_or_enum_name
+            }) // Check if struct/enum name appears in the content
             .cloned()
             .collect()
     }


### PR DESCRIPTION
sql-gen has a function `detect_dependencies` in `DbSetsFsWriter` which automatically includes custom types defined elsewhere when they are use by each model generated.
However, if the typeof the dependencies is enclosed in an `Option` enum, the dependency is not detected. 
This change fixes that. 